### PR TITLE
Issue #31: Fixed opacity of leaves for firefox

### DIFF
--- a/src/scripts/leaves.js
+++ b/src/scripts/leaves.js
@@ -94,6 +94,6 @@ start()
 mainLoop()
 
 window.onscroll = function (e) {
-  var factor = Math.max(Math.min(indow.pageYOffset / 500, 1), 0)
+  var factor = Math.max(Math.min(window.pageYOffset / 500, 1), 0)
   canvas.style.opacity = 0.1 + 0.8 * (1 - factor)
 }

--- a/src/scripts/leaves.js
+++ b/src/scripts/leaves.js
@@ -94,6 +94,6 @@ start()
 mainLoop()
 
 window.onscroll = function (e) {
-  var factor = Math.max(Math.min(document.body.scrollTop / 500, 1), 0)
+  var factor = Math.max(Math.min(indow.pageYOffset / 500, 1), 0)
   canvas.style.opacity = 0.1 + 0.8 * (1 - factor)
 }


### PR DESCRIPTION
Fixed opacity of leaves in firefox.
`document.body.scrollTop` depending on the rendering mode of the browser returns 0. `window.pageYOffset` seems to work for all

See: [here](https://stackoverflow.com/questions/7435843/window-top-document-body-scrolltop-not-working-in-chrome-or-firefox#7436602)
Also: [window.pageYOffset](https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollY)

**Tested for:**
- firefox 49.0.1
- chrome 53.0.2785.116 (64-bit)
- safari Version 10.0 (12602.1.50.0.10)
